### PR TITLE
Use the kid from the JsonWebKey as the id for the X509SecurityToken

### DIFF
--- a/source/AccessTokenValidation/Plumbing/DiscoveryDocumentIssuerSecurityTokenProvider.cs
+++ b/source/AccessTokenValidation/Plumbing/DiscoveryDocumentIssuerSecurityTokenProvider.cs
@@ -149,7 +149,7 @@ namespace IdentityServer3.AccessTokenValidation
                 }
 
                 var tokens = from key in result.JsonWebKeySet.Keys
-                             select new X509SecurityToken(new X509Certificate2(Convert.FromBase64String(key.X5c.First())));
+                             select new X509SecurityToken(new X509Certificate2(Convert.FromBase64String(key.X5c.First())), key.Kid);
                 
                 _issuer = result.Issuer;
                 _tokens = tokens;


### PR DESCRIPTION
Hey
The X509SecurityToken created from the key was created with default random id. I've changed it to be the id of the key instead. This was not a bug, because the JWT handler was looking for a key based on the x5t that present in the JWT and in the JWK. In my situation the JWT will not necessary will have a x5t (as it will not be signed using X509Certificate) so I need to filter the keys by the id. This, among with my previous PR allow my to accomplish that.
Thanks,
Omer
